### PR TITLE
Update to 0.4.0

### DIFF
--- a/com.github.finefindus.eyedropper.json
+++ b/com.github.finefindus.eyedropper.json
@@ -1,7 +1,7 @@
 {
     "id": "com.github.finefindus.eyedropper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
     "command": "eyedropper",
@@ -22,8 +22,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/FineFindus/eyedropper/releases/download/0.3.1/eyedropper-0.3.1.tar.xz",
-                    "sha256": "b88d20e36bf99b4d3182fd0f29692f1491af20d8d1d400848599c723e92c092c"
+                    "url": "https://github.com/FineFindus/eyedropper/releases/download/0.4.0/eyedropper-0.4.0.tar.xz",
+                    "sha256": "48831bd449ae6374450c8f052c59182b1cf296560d60ff9f9ee71fb74dbc032d"
                 }
             ]
         }

--- a/com.github.finefindus.eyedropper.json
+++ b/com.github.finefindus.eyedropper.json
@@ -22,8 +22,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/FineFindus/eyedropper/releases/download/0.3.0/eyedropper-0.3.0.tar.xz",
-                    "sha256": "13825ddeb675b7bff2b7db2e6ed0a28ce6ac3ae6008f21ea5f1ff85608255fa6"
+                    "url": "https://github.com/FineFindus/eyedropper/releases/download/0.3.1/eyedropper-0.3.1.tar.xz",
+                    "sha256": "b88d20e36bf99b4d3182fd0f29692f1491af20d8d1d400848599c723e92c092c"
                 }
             ]
         }


### PR DESCRIPTION
This updates to the newest release (0.4.0). It also updates the used `runtime-version` to 43, since the newest release requires libadwaita 1.2.