### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/com.github.finefindus.eyedropper.json
+++ b/com.github.finefindus.eyedropper.json
@@ -22,8 +22,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/FineFindus/eyedropper/releases/download/v0.5.0/eyedropper-0.5.0.tar.xz",
-                    "sha256": "fcff7dad12ff346d10a6d23dc2b01f3590f120a912680af072e02651877dd0f6"
+                    "url": "https://github.com/FineFindus/eyedropper/releases/download/v0.5.1/eyedropper-0.5.1.tar.xz",
+                    "sha256": "7b96c0b191b9a4fb9c34ae318b0da564eae13ca3c8a214e69bfebae8678fe31f"
                 }
             ]
         }


### PR DESCRIPTION
Updates to the new [0.5.1 release](https://github.com/FineFindus/eyedropper/releases/tag/v0.5.1).