### PR TITLE
Update runtime-version to 45 & add --share=ipc argument

### DIFF
--- a/com.github.finefindus.eyedropper.json
+++ b/com.github.finefindus.eyedropper.json
@@ -1,33 +1,34 @@
 {
-    "id": "com.github.finefindus.eyedropper",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
-    "sdk": "org.gnome.Sdk",
-    "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.rust-stable"
-    ],
-    "command": "eyedropper",
-    "finish-args": [
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--device=dri",
-        "--env=G_MESSAGES_DEBUG=none",
-        "--env=RUST_BACKTRACE=1"
-    ],
-    "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin"
-    },
-    "modules": [
+  "id": "com.github.finefindus.eyedropper",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "45",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "command": "eyedropper",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--env=G_MESSAGES_DEBUG=none",
+    "--env=RUST_BACKTRACE=1"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/rust-stable/bin"
+  },
+  "modules": [
+    {
+      "name": "eyedropper",
+      "buildsystem": "meson",
+      "sources": [
         {
-            "name": "eyedropper",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/FineFindus/eyedropper/releases/download/v0.6.0/eyedropper-0.6.0.tar.xz",
-                    "sha256": "9e92ca182c1cfd2433f2367bd1dd4c2c4db1f1032e5a6c1f66f8436db453f9be"
-                }
-            ]
+          "type": "archive",
+          "url": "https://github.com/FineFindus/eyedropper/releases/download/v0.6.0/eyedropper-0.6.0.tar.xz",
+          "sha256": "9e92ca182c1cfd2433f2367bd1dd4c2c4db1f1032e5a6c1f66f8436db453f9be"
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Added the "--share=ipc" argument to solve the "finish-args-x11-without-ipc" linter error.